### PR TITLE
More client-socket options (-keepalive, -nagle)

### DIFF
--- a/win/tclWinIocpTcp.c
+++ b/win/tclWinIocpTcp.c
@@ -1302,7 +1302,9 @@ IocpTclCode TcpListenerGetOption(
         Tcl_DStringAppend(dsPtr, integerSpace, -1);
         return TCL_OK;
     default:
-        Tcl_SetObjResult(interp, Tcl_ObjPrintf("Internal error: invalid socket option index %d", opt));
+        if (interp) {
+            Tcl_SetObjResult(interp, Tcl_ObjPrintf("Internal error: invalid socket option index %d", opt));
+        }
         return TCL_ERROR;
     }
 }

--- a/win/tclWinIocpUtil.c
+++ b/win/tclWinIocpUtil.c
@@ -204,15 +204,14 @@ void IocpSetTclErrnoFromWin32(IocpWinError winError)
  *
  *------------------------------------------------------------------------
  */
-void IocpSetInterpPosixErrorFromWin32 (
+void IocpSetInterpPosixErrorFromWin32(
     Tcl_Interp *interp,         /* May be NULL */
     IocpWinError winError,      /* Win32 error code */
     const char *messagePrefix)  /* A message prefix if any. May be NULL */
 {
-    
     IocpSetTclErrnoFromWin32(winError);
     if (interp != NULL) {
-        const char *posixMessage = Tcl_ErrnoMsg(Tcl_GetErrno());
+        const char *posixMessage = Tcl_PosixError(interp);
         if (messagePrefix == NULL) {
             Tcl_SetResult(interp, (char *)posixMessage, TCL_STATIC);
         }
@@ -221,7 +220,6 @@ void IocpSetInterpPosixErrorFromWin32 (
         }
     }
 }
-
 
 /*
  *------------------------------------------------------------------------

--- a/win/tclWinIocpWinsock.h
+++ b/win/tclWinIocpWinsock.h
@@ -85,6 +85,8 @@ enum IocpWinsockOption {
     IOCP_WINSOCK_OPT_MAXPENDINGACCEPTS,
     IOCP_WINSOCK_OPT_SOSNDBUF,
     IOCP_WINSOCK_OPT_SORCVBUF,
+    IOCP_WINSOCK_OPT_KEEPALIVE,
+    IOCP_WINSOCK_OPT_NAGLE,
     IOCP_WINSOCK_OPT_INVALID        /* Must be last */
 };
 extern const char*iocpWinsockOptionNames[];


### PR DESCRIPTION
The PR provides a backport of socket option `-keepalive` (`SO_KEEPALIVE`) and `-nagle` (`TCP_NODELAY`) from Tcl (TCL_FEATURE_KEEPALIVE_NAGLE).

The branch is a descendant of patch-1 (thus contains #12), but I can rebase it if unwanted.
